### PR TITLE
制限時間を超えるとゲームオーバーになる機能を追加

### DIFF
--- a/Assets/Fields/Prefabs/Terrain.prefab
+++ b/Assets/Fields/Prefabs/Terrain.prefab
@@ -1019,7 +1019,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8dc5f285cd6f442bea342a27da65a27d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  countDownSeconds: 5
+  countDownSeconds: 180
   timeLimitText: {fileID: 1583627566284966823}
   gameView: {fileID: 6975210967958099569}
   loseView: {fileID: 4408935942038496810}

--- a/Assets/Fields/Prefabs/Terrain.prefab
+++ b/Assets/Fields/Prefabs/Terrain.prefab
@@ -701,7 +701,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: You lose...
+  m_text: Game over...
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
   m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
@@ -1019,8 +1019,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8dc5f285cd6f442bea342a27da65a27d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  countDownSeconds: 30
+  countDownSeconds: 5
   timeLimitText: {fileID: 1583627566284966823}
+  gameView: {fileID: 6975210967958099569}
+  loseView: {fileID: 4408935942038496810}
 --- !u!1 &9191882029934925219
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Oculus/OculusProjectConfig.asset
+++ b/Assets/Oculus/OculusProjectConfig.asset
@@ -40,5 +40,5 @@ MonoBehaviour:
   systemSplashScreen: {fileID: 0}
   systemSplashScreenType: 0
   _systemLoadingScreenBackground: 0
-  ovrPluginMd5Win64: e8cfe66d40bc858ac6a51dd265d3b2f7e7c26f9dced0151d581cb63937c7775f
-  ovrPluginMd5Android: c7bb9a379e186c4b2726b69bbb7d3acee99e8cd9b0be321c184c02e1903cce67
+  ovrPluginMd5Win64: e8cfe66d40bc858ac6a51dd265d3b2f7b46b5a5739606594cc8f75ac06d9a926
+  ovrPluginMd5Android: c7bb9a379e186c4b2726b69bbb7d3ace992f10eefb44688f7553b9119901fca7

--- a/Assets/UI/displayTimeLimit.cs
+++ b/Assets/UI/displayTimeLimit.cs
@@ -3,8 +3,10 @@ using TMPro;
 
 public class displayTimeLimit : MonoBehaviour
 {
-    [SerializeField] private float countDownSeconds = 30f;
+    [SerializeField] private float countDownSeconds;  // 3 minutes in seconds
     [SerializeField] public TextMeshProUGUI timeLimitText;
+    [SerializeField] public GameObject gameView;
+    [SerializeField] public GameObject loseView;
 
     private void Start()
     {
@@ -22,11 +24,16 @@ public class displayTimeLimit : MonoBehaviour
         else
         {
             timeLimitText.text = "Game over";
+            gameView.SetActive(false);
+            loseView.SetActive(true);
         }
     }
 
     private void UpdateTimeDisplay(float time)
     {
-        timeLimitText.text = "0 : " + Mathf.Ceil(time).ToString("0");
+        int minutes = Mathf.FloorToInt(time / 60);
+        int seconds = Mathf.FloorToInt(time % 60);
+        timeLimitText.text = string.Format("{0:0}:{1:00}", minutes, seconds);
     }
 }
+

--- a/ProjectSettings/QualitySettings.asset
+++ b/ProjectSettings/QualitySettings.asset
@@ -267,7 +267,7 @@ QualitySettings:
     globalTextureMipmapLimit: 0
     textureMipmapLimitSettings: []
     anisotropicTextures: 1
-    antiAliasing: 2
+    antiAliasing: 0
     softParticles: 1
     softVegetation: 1
     realtimeReflectionProbes: 1


### PR DESCRIPTION
制限時間を30秒から3分に変更しました。
敵キャラクター3体を制限時間以内に倒すことができなければゲームオーバーの画面が表示されます。